### PR TITLE
feat: 기간별 감정 추세 조회, 감정별 필터링

### DIFF
--- a/src/main/java/com/moodmate/controller/TrackingController.java
+++ b/src/main/java/com/moodmate/controller/TrackingController.java
@@ -3,6 +3,7 @@ package com.moodmate.controller;
 import com.moodmate.domain.tracking.TrackingService;
 import com.moodmate.domain.tracking.dto.frequency.EmotionFrequencyResponse;
 import com.moodmate.domain.tracking.dto.ratio.EmotionRatioResponse;
+import com.moodmate.domain.tracking.dto.trend.EmotionTrendResponse;
 import com.moodmate.domain.user.ouath.CustomOauth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,6 +23,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Tag(name = "Tracking-Controller", description = "감정 트래킹 관련 API")
 @RestController
@@ -33,7 +37,6 @@ public class TrackingController {
 
     @GetMapping("/emotions/frequency")
     @Operation(summary = "기간별 감정 빈도 조회",
-            security = @SecurityRequirement(name = "bearer-key"),
             parameters = {
                     @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
                     @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01")
@@ -55,7 +58,6 @@ public class TrackingController {
 
     @GetMapping("/emotions/ratio")
     @Operation(summary = "기간별 감정 강도 비율 조회",
-            security = @SecurityRequirement(name = "bearer-key"),
             parameters = {
                     @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
                     @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01")
@@ -73,5 +75,42 @@ public class TrackingController {
             @AuthenticationPrincipal CustomOauth2User userDetails
     ) {
         return ResponseEntity.ok(trackingService.getEmotionRatio(userDetails.getUser().getId(), startDate, endDate));
+    }
+
+    @GetMapping("/emotions/trend")
+    @Operation(summary = "기간별 감정 추세 조회",
+            description = "콤마(,)로 구분된 감정 목록을 전달하면 해당 감정만 조회합니다. 비우면 전체 조회.",
+            parameters = {
+                    @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
+                    @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01"),
+                    @Parameter(name = "emotions", description = "조회할 감정 목록 (공백 없이 콤마 구분)", example = "기쁨,슬픔")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EmotionTrendResponse.class)))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청(잘못된 기간 설정 등)", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "로그인하지 않은 사용자", content = @Content)
+            }
+    )
+    public ResponseEntity<EmotionTrendResponse> getEmotionTrend(
+            @AuthenticationPrincipal CustomOauth2User userDetails,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String emotions
+    ) {
+        List<String> emotionList = (emotions == null || emotions.isBlank())
+                ? Collections.emptyList()
+                : Arrays.stream(emotions.split(","))
+                .map(String::trim)
+                .toList();
+
+        EmotionTrendResponse response = trackingService.getEmotionTrend(
+                userDetails.getUser().getId(),
+                startDate,
+                endDate,
+                emotionList
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/moodmate/domain/diary/repository/DiaryEmotionRepository.java
+++ b/src/main/java/com/moodmate/domain/diary/repository/DiaryEmotionRepository.java
@@ -1,7 +1,7 @@
 package com.moodmate.domain.diary.repository;
 
 import com.moodmate.domain.diary.entity.DiaryEmotion;
-import com.moodmate.domain.tracking.dto.frequency.EmotionFrequencyDto;
+import com.moodmate.domain.tracking.dto.frequency.FrequencyDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,15 +10,15 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface DiaryEmotionRepository extends JpaRepository<DiaryEmotion, Long> {
-    @Query("SELECT new com.moodmate.domain.tracking.dto.frequency.EmotionFrequencyDto(de.emotion.name, COUNT(de)) " +
+    @Query("SELECT new com.moodmate.domain.tracking.dto.frequency.FrequencyDto(de.emotion.name, COUNT(de)) " +
             "FROM DiaryEmotion de " +
             "WHERE de.diary.user.id = :userId " +
             "AND de.diary.date BETWEEN :startDate AND :endDate " +
             "GROUP BY de.emotion " +
             "ORDER BY COUNT(de) DESC")
-    List<EmotionFrequencyDto> countEmotionsByPeriod(@Param("userId") Long userId,
-                                                    @Param("startDate") LocalDate startDate,
-                                                    @Param("endDate") LocalDate endDate);
+    List<FrequencyDto> countEmotionsByPeriod(@Param("userId") Long userId,
+                                             @Param("startDate") LocalDate startDate,
+                                             @Param("endDate") LocalDate endDate);
 
     @Query("SELECT de.emotion.name, SUM(de.intensity) " +
             "FROM DiaryEmotion de " +
@@ -28,4 +28,21 @@ public interface DiaryEmotionRepository extends JpaRepository<DiaryEmotion, Long
     List<Object[]> sumEmotionIntensityByPeriod(@Param("userId") Long userId,
                                                @Param("startDate") LocalDate startDate,
                                                @Param("endDate") LocalDate endDate);
+
+    @Query("""
+        SELECT e.name, d.date, de.intensity
+        FROM DiaryEmotion de
+        JOIN de.diary d
+        JOIN de.emotion e
+        WHERE d.user.id = :userId
+          AND d.date BETWEEN :startDate AND :endDate
+          AND (:emotions IS NULL OR e.name IN :emotions)
+        ORDER BY e.name, d.date, de.id
+    """)
+    List<Object[]> findEmotionTimeline(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("emotions") List<String> emotions
+    );
 }

--- a/src/main/java/com/moodmate/domain/tracking/dto/frequency/EmotionFrequencyResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/frequency/EmotionFrequencyResponse.java
@@ -8,6 +8,9 @@ public record EmotionFrequencyResponse(
         @Schema(description = "메타 데이터")
         FrequencyMeta meta,
 
-        @Schema(description = "감정 빈도 데이터")
-        List<EmotionFrequencyDto> data
+        @Schema(
+                description = "감정 빈도 데이터",
+                example = "[{\"emotion\":\"기쁨\",\"count\":2},{\"emotion\":\"슬픔\",\"count\":1}]"
+        )
+        List<FrequencyDto> data
 ) {}

--- a/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyDto.java
@@ -2,7 +2,7 @@ package com.moodmate.domain.tracking.dto.frequency;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record EmotionFrequencyDto(
+public record FrequencyDto(
         @Schema(description = "감정 이름", example = "기쁨")
         String emotion,
 

--- a/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyMeta.java
@@ -13,7 +13,7 @@ public record FrequencyMeta(
 
     LocalDate endDate,
 
-    @Schema(description = "감정 개수", example = "1")
+    @Schema(description = "데이터 수", example = "2")
     long totalRecords,
 
     LocalDateTime generatedAt)  implements TrackingMetaBase {}

--- a/src/main/java/com/moodmate/domain/tracking/dto/ratio/EmotionRatioResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/ratio/EmotionRatioResponse.java
@@ -9,8 +9,11 @@ public record EmotionRatioResponse(
         @Schema(description = "메타 데이터")
         RatioMeta meta,
 
-        @Schema(description = "감정 비율 데이터")
-        List<EmotionRatioDto> data
+        @Schema(
+                description = "감정 강도 비율 데이터",
+                example = "[{\"emotion\":\"기쁨\",\"count\":0.7},{\"emotion\":\"슬픔\",\"count\":0.3}]"
+        )
+        List<RatioDto> data
 ) {
 
 }

--- a/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioDto.java
@@ -2,7 +2,7 @@ package com.moodmate.domain.tracking.dto.ratio;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record EmotionRatioDto(
+public record RatioDto(
         @Schema(description = "감정 이름", example = "기쁨")
         String emotion,
 

--- a/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioMeta.java
@@ -13,7 +13,7 @@ public record RatioMeta(
 
         LocalDate endDate,
 
-        @Schema(description = "감정 개수", example = "1")
+        @Schema(description = "데이터 개수", example = "2")
         long totalRecords,
 
         LocalDateTime generatedAt)  implements TrackingMetaBase

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/EmotionTrendResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/EmotionTrendResponse.java
@@ -1,0 +1,12 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record EmotionTrendResponse(
+        @Schema(description = "메타 데이터")
+        TimeLineMeta meta,
+
+        @Schema(description = "타임 라인 데이터")
+        List<TimeLineDto> data){}

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineDto.java
@@ -1,0 +1,17 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record TimeLineDto(
+        @Schema(description = "감정 이름", example = "기쁨")
+        String emotion,
+
+        @Schema(
+                description = "감정 타임 라인",
+                example = "[{\"day\":\"2025-09-01\",\"intensity\":5},{\"day\":\"2025-09-15\",\"intensity\":3}]"
+        )
+        List<TimeLinePointDto> timeline
+) {
+}

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineMeta.java
@@ -1,0 +1,20 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import com.moodmate.domain.tracking.dto.TrackingMetaBase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TimeLineMeta(
+        Long userId,
+
+       LocalDate startDate,
+
+       LocalDate endDate,
+
+       @Schema(description = "조회한 감정", example = "[\'기쁨\', \'슬픔\']")
+       List<String> selectedEmotions,
+
+       LocalDateTime generatedAt)  implements TrackingMetaBase {}

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLinePointDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLinePointDto.java
@@ -1,0 +1,13 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record TimeLinePointDto(
+        @Schema(description = "날짜", example = "2025-09-01")
+        LocalDate date,
+
+        @Schema(description = "감정 강도(1 ~ 5)", example = "3")
+        int intensity
+) {}

--- a/src/test/java/com/moodmate/domain/tracking/TrackingServiceTest.java
+++ b/src/test/java/com/moodmate/domain/tracking/TrackingServiceTest.java
@@ -1,6 +1,7 @@
 package com.moodmate.domain.tracking;
 
 import com.moodmate.domain.diary.repository.DiaryEmotionRepository;
+import com.moodmate.domain.emotion.EmotionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,11 +17,14 @@ class TrackingServiceTest {
     private TrackingService trackingService;
     private DiaryEmotionRepository diaryEmotionRepository;
 
+    private EmotionRepository emotionRepository;
+
     @BeforeEach
     void setUp() {
         // Repository는 mock 처리
         diaryEmotionRepository = mock(DiaryEmotionRepository.class);
-        trackingService = new TrackingService(diaryEmotionRepository);
+        emotionRepository = mock(EmotionRepository.class);
+        trackingService = new TrackingService(diaryEmotionRepository, emotionRepository);
     }
 
     @Test


### PR DESCRIPTION
### 기간별 감정 추세 조회
- 사용 예시: GET /api/analytics/emotions/trend?startDate=2025-09-01&endDate=2025-09-30&emotions=기쁨,슬픔
- emotions 없이 조회 시 전체 감정 조회
<img width="669" height="601" alt="image" src="https://github.com/user-attachments/assets/c6738b51-2ad0-4dcf-840f-205606290a6a" />
<img width="565" height="736" alt="image" src="https://github.com/user-attachments/assets/11dbcded-3d79-4e6c-9551-0694bb39c11d" />
