### PR TITLE
fix: 일기 정보 존재 시 회원 탈퇴 안되는 오류 수정(문제 3)

### DIFF
--- a/src/main/java/com/moodmate/controller/TrackingController.java
+++ b/src/main/java/com/moodmate/controller/TrackingController.java
@@ -3,6 +3,7 @@ package com.moodmate.controller;
 import com.moodmate.domain.tracking.TrackingService;
 import com.moodmate.domain.tracking.dto.frequency.EmotionFrequencyResponse;
 import com.moodmate.domain.tracking.dto.ratio.EmotionRatioResponse;
+import com.moodmate.domain.tracking.dto.trend.EmotionTrendResponse;
 import com.moodmate.domain.user.ouath.CustomOauth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,6 +23,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Tag(name = "Tracking-Controller", description = "감정 트래킹 관련 API")
 @RestController
@@ -33,7 +37,6 @@ public class TrackingController {
 
     @GetMapping("/emotions/frequency")
     @Operation(summary = "기간별 감정 빈도 조회",
-            security = @SecurityRequirement(name = "bearer-key"),
             parameters = {
                     @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
                     @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01")
@@ -55,7 +58,6 @@ public class TrackingController {
 
     @GetMapping("/emotions/ratio")
     @Operation(summary = "기간별 감정 강도 비율 조회",
-            security = @SecurityRequirement(name = "bearer-key"),
             parameters = {
                     @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
                     @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01")
@@ -73,5 +75,42 @@ public class TrackingController {
             @AuthenticationPrincipal CustomOauth2User userDetails
     ) {
         return ResponseEntity.ok(trackingService.getEmotionRatio(userDetails.getUser().getId(), startDate, endDate));
+    }
+
+    @GetMapping("/emotions/trend")
+    @Operation(summary = "기간별 감정 추세 조회",
+            description = "콤마(,)로 구분된 감정 목록을 전달하면 해당 감정만 조회합니다. 비우면 전체 조회.",
+            parameters = {
+                    @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
+                    @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01"),
+                    @Parameter(name = "emotions", description = "조회할 감정 목록 (공백 없이 콤마 구분)", example = "기쁨,슬픔")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = EmotionTrendResponse.class)))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청(잘못된 기간 설정 등)", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "로그인하지 않은 사용자", content = @Content)
+            }
+    )
+    public ResponseEntity<EmotionTrendResponse> getEmotionTrend(
+            @AuthenticationPrincipal CustomOauth2User userDetails,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(required = false) String emotions
+    ) {
+        List<String> emotionList = (emotions == null || emotions.isBlank())
+                ? Collections.emptyList()
+                : Arrays.stream(emotions.split(","))
+                .map(String::trim)
+                .toList();
+
+        EmotionTrendResponse response = trackingService.getEmotionTrend(
+                userDetails.getUser().getId(),
+                startDate,
+                endDate,
+                emotionList
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/moodmate/controller/UserController.java
+++ b/src/main/java/com/moodmate/controller/UserController.java
@@ -5,6 +5,7 @@ import com.moodmate.domain.user.dto.UserProfileRequest;
 import com.moodmate.domain.user.dto.UserProfileResponse;
 import com.moodmate.domain.user.entity.User;
 import com.moodmate.domain.user.ouath.CustomOauth2User;
+import com.moodmate.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -25,7 +26,8 @@ import java.util.Map;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
-    private final UserRepository memberRepository;
+    private final UserRepository userRepository;
+    private final UserService userService;
 
     @GetMapping("/me")
     @Operation(summary = "회원 정보 조회",
@@ -61,7 +63,7 @@ public class UserController {
             @AuthenticationPrincipal CustomOauth2User customOauth2User) {
         User user = customOauth2User.getUser();
         user.setUsername(request.username()); // 닉네임 수정
-        memberRepository.save(user); // DB에 저장
+        userRepository.save(user); // DB에 저장
         return ResponseEntity.ok(new UserProfileResponse(user));
     }
 
@@ -78,10 +80,7 @@ public class UserController {
         User user = customOauth2User.getUser();
 
         // 사용자 삭제
-        memberRepository.delete(user);
-
-//        // JWT 토큰 만료 처리를 클라이언트에서 할 수 있으므로, 삭제만 처리
-////        return ResponseEntity.noContent().build();  // 204 No Content 응답
+        userRepository.delete(user);
 
         return ResponseEntity.ok(Map.of(
                 "message", "회원 탈퇴가 완료되었습니다."

--- a/src/main/java/com/moodmate/dev/TestInitializer.java
+++ b/src/main/java/com/moodmate/dev/TestInitializer.java
@@ -22,14 +22,15 @@ public class TestInitializer implements CommandLineRunner {
     @Override
     public void run(String... args) {
         // --- test User 생성 ---
-        User user = User.builder()
-                .loginId("moodmate001")
-                .provider("moodmate")
-                .providerId("001")
-                .role(Role.USER)
-                .email("test@example.com")
-                .username("test")
-                .build();
+        User user = User.createOAuthUser(
+                "moodmate001",
+                "moodmate",
+                "001",
+                Role.USER,
+                "test@example.com",
+                "test"
+        );
+
         userRepository.findByEmail("test@example.com")
                 .orElseGet(() -> userRepository.save(user));
 

--- a/src/main/java/com/moodmate/domain/diary/DiaryService.java
+++ b/src/main/java/com/moodmate/domain/diary/DiaryService.java
@@ -11,6 +11,7 @@ import com.moodmate.domain.emotion.Emotion;
 import com.moodmate.domain.user.entity.User;
 import com.moodmate.domain.emotion.EmotionRepository;
 import com.moodmate.domain.user.UserRepository;
+import com.moodmate.domain.user.service.UserService;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +49,7 @@ public class DiaryService {
         }
 
         // 저장 (Cascade로 DiaryEmotion까지 저장됨)
+        user.addDiary(diary);
         diaryRepository.save(diary);
 
         return diary.getId();

--- a/src/main/java/com/moodmate/domain/diary/entity/DiaryEmotion.java
+++ b/src/main/java/com/moodmate/domain/diary/entity/DiaryEmotion.java
@@ -14,10 +14,10 @@ public class DiaryEmotion {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Diary diary;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Emotion emotion;
 
     private int intensity;

--- a/src/main/java/com/moodmate/domain/diary/repository/DiaryEmotionRepository.java
+++ b/src/main/java/com/moodmate/domain/diary/repository/DiaryEmotionRepository.java
@@ -1,7 +1,7 @@
 package com.moodmate.domain.diary.repository;
 
 import com.moodmate.domain.diary.entity.DiaryEmotion;
-import com.moodmate.domain.tracking.dto.frequency.EmotionFrequencyDto;
+import com.moodmate.domain.tracking.dto.frequency.FrequencyDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,15 +10,15 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface DiaryEmotionRepository extends JpaRepository<DiaryEmotion, Long> {
-    @Query("SELECT new com.moodmate.domain.tracking.dto.frequency.EmotionFrequencyDto(de.emotion.name, COUNT(de)) " +
+    @Query("SELECT new com.moodmate.domain.tracking.dto.frequency.FrequencyDto(de.emotion.name, COUNT(de)) " +
             "FROM DiaryEmotion de " +
             "WHERE de.diary.user.id = :userId " +
             "AND de.diary.date BETWEEN :startDate AND :endDate " +
             "GROUP BY de.emotion " +
             "ORDER BY COUNT(de) DESC")
-    List<EmotionFrequencyDto> countEmotionsByPeriod(@Param("userId") Long userId,
-                                                    @Param("startDate") LocalDate startDate,
-                                                    @Param("endDate") LocalDate endDate);
+    List<FrequencyDto> countEmotionsByPeriod(@Param("userId") Long userId,
+                                             @Param("startDate") LocalDate startDate,
+                                             @Param("endDate") LocalDate endDate);
 
     @Query("SELECT de.emotion.name, SUM(de.intensity) " +
             "FROM DiaryEmotion de " +
@@ -28,4 +28,21 @@ public interface DiaryEmotionRepository extends JpaRepository<DiaryEmotion, Long
     List<Object[]> sumEmotionIntensityByPeriod(@Param("userId") Long userId,
                                                @Param("startDate") LocalDate startDate,
                                                @Param("endDate") LocalDate endDate);
+
+    @Query("""
+        SELECT e.name, d.date, de.intensity
+        FROM DiaryEmotion de
+        JOIN de.diary d
+        JOIN de.emotion e
+        WHERE d.user.id = :userId
+          AND d.date BETWEEN :startDate AND :endDate
+          AND (:emotions IS NULL OR e.name IN :emotions)
+        ORDER BY e.name, d.date, de.id
+    """)
+    List<Object[]> findEmotionTimeline(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("emotions") List<String> emotions
+    );
 }

--- a/src/main/java/com/moodmate/domain/tracking/dto/frequency/EmotionFrequencyResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/frequency/EmotionFrequencyResponse.java
@@ -8,6 +8,9 @@ public record EmotionFrequencyResponse(
         @Schema(description = "메타 데이터")
         FrequencyMeta meta,
 
-        @Schema(description = "감정 빈도 데이터")
-        List<EmotionFrequencyDto> data
+        @Schema(
+                description = "감정 빈도 데이터",
+                example = "[{\"emotion\":\"기쁨\",\"count\":2},{\"emotion\":\"슬픔\",\"count\":1}]"
+        )
+        List<FrequencyDto> data
 ) {}

--- a/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyDto.java
@@ -2,7 +2,7 @@ package com.moodmate.domain.tracking.dto.frequency;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record EmotionFrequencyDto(
+public record FrequencyDto(
         @Schema(description = "감정 이름", example = "기쁨")
         String emotion,
 

--- a/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/frequency/FrequencyMeta.java
@@ -13,7 +13,7 @@ public record FrequencyMeta(
 
     LocalDate endDate,
 
-    @Schema(description = "감정 개수", example = "1")
+    @Schema(description = "데이터 수", example = "2")
     long totalRecords,
 
     LocalDateTime generatedAt)  implements TrackingMetaBase {}

--- a/src/main/java/com/moodmate/domain/tracking/dto/ratio/EmotionRatioResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/ratio/EmotionRatioResponse.java
@@ -9,8 +9,11 @@ public record EmotionRatioResponse(
         @Schema(description = "메타 데이터")
         RatioMeta meta,
 
-        @Schema(description = "감정 비율 데이터")
-        List<EmotionRatioDto> data
+        @Schema(
+                description = "감정 강도 비율 데이터",
+                example = "[{\"emotion\":\"기쁨\",\"count\":0.7},{\"emotion\":\"슬픔\",\"count\":0.3}]"
+        )
+        List<RatioDto> data
 ) {
 
 }

--- a/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioDto.java
@@ -2,7 +2,7 @@ package com.moodmate.domain.tracking.dto.ratio;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record EmotionRatioDto(
+public record RatioDto(
         @Schema(description = "감정 이름", example = "기쁨")
         String emotion,
 

--- a/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/ratio/RatioMeta.java
@@ -13,7 +13,7 @@ public record RatioMeta(
 
         LocalDate endDate,
 
-        @Schema(description = "감정 개수", example = "1")
+        @Schema(description = "데이터 개수", example = "2")
         long totalRecords,
 
         LocalDateTime generatedAt)  implements TrackingMetaBase

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/EmotionTrendResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/EmotionTrendResponse.java
@@ -1,0 +1,12 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record EmotionTrendResponse(
+        @Schema(description = "메타 데이터")
+        TimeLineMeta meta,
+
+        @Schema(description = "타임 라인 데이터")
+        List<TimeLineDto> data){}

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineDto.java
@@ -1,0 +1,17 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record TimeLineDto(
+        @Schema(description = "감정 이름", example = "기쁨")
+        String emotion,
+
+        @Schema(
+                description = "감정 타임 라인",
+                example = "[{\"day\":\"2025-09-01\",\"intensity\":5},{\"day\":\"2025-09-15\",\"intensity\":3}]"
+        )
+        List<TimeLinePointDto> timeline
+) {
+}

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLineMeta.java
@@ -1,0 +1,20 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import com.moodmate.domain.tracking.dto.TrackingMetaBase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TimeLineMeta(
+        Long userId,
+
+       LocalDate startDate,
+
+       LocalDate endDate,
+
+       @Schema(description = "조회한 감정", example = "[\'기쁨\', \'슬픔\']")
+       List<String> selectedEmotions,
+
+       LocalDateTime generatedAt)  implements TrackingMetaBase {}

--- a/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLinePointDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dto/trend/TimeLinePointDto.java
@@ -1,0 +1,13 @@
+package com.moodmate.domain.tracking.dto.trend;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record TimeLinePointDto(
+        @Schema(description = "날짜", example = "2025-09-01")
+        LocalDate date,
+
+        @Schema(description = "감정 강도(1 ~ 5)", example = "3")
+        int intensity
+) {}

--- a/src/main/java/com/moodmate/domain/user/UserRepository.java
+++ b/src/main/java/com/moodmate/domain/user/UserRepository.java
@@ -8,6 +8,4 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByLoginId(String loginId);
     Optional<User> findByEmail(String email);
-    boolean existsByLoginId(String loginId);
-
 }

--- a/src/main/java/com/moodmate/domain/user/entity/User.java
+++ b/src/main/java/com/moodmate/domain/user/entity/User.java
@@ -1,14 +1,17 @@
 package com.moodmate.domain.user.entity;
 
+import com.moodmate.domain.diary.entity.Diary;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "users")
@@ -37,8 +40,30 @@ public class User {
 
     private String pictureUrl;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Diary> diaries = new ArrayList<>();
+
+    // 편의 메서드
+    public void addDiary(Diary diary) {
+        diaries.add(diary);
+        diary.setUser(this);
+    }
+
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    public static User createOAuthUser(String loginId, String provider, String providerId,
+                                       Role role, String pictureUrl, String email) {
+        User user = new User();
+        user.loginId = loginId;
+        user.provider = provider;
+        user.providerId = providerId;
+        user.role = role;
+        user.pictureUrl = pictureUrl;
+        user.email = email;
+        user.username = null;
+        return user;
     }
 
 }

--- a/src/main/java/com/moodmate/domain/user/service/UserService.java
+++ b/src/main/java/com/moodmate/domain/user/service/UserService.java
@@ -17,15 +17,14 @@ public class UserService {
         String loginId = provider + "_" + userInfo.getProviderId();
 
         return userRepository.findByLoginId(loginId)
-                .orElseGet(() -> userRepository.save(User.builder()
-                        .loginId(loginId)
-                        .provider(provider)
-                        .providerId(userInfo.getProviderId())
-                        .role(Role.USER)
-                        .pictureUrl(userInfo.getPicture())
-                        .email(userInfo.getEmail())
-                        .username(null)
-                        .build()));
+                .orElseGet(() -> userRepository.save(User.createOAuthUser(
+                        loginId,
+                        provider,
+                        userInfo.getProviderId(),
+                        Role.USER,
+                        userInfo.getPicture(),
+                        userInfo.getEmail()
+                )));
     }
 }
 

--- a/src/test/java/com/moodmate/api/TestUtils.java
+++ b/src/test/java/com/moodmate/api/TestUtils.java
@@ -8,15 +8,13 @@ import com.moodmate.domain.user.entity.User;
 public class TestUtils {
 
     public static User createUser(UserRepository userRepository) {
-        return userRepository.save(User.builder()
-                .username("테스트유저")
-                .role(Role.USER)
-                .loginId("google_123")
-                .provider("google")
-                .providerId("123")
-                .email("test123@example.com")
-                .pictureUrl("http://example.com/img.png")
-                .build());
+        return userRepository.save(User.createOAuthUser(
+                "google_123",
+                "google",
+                "123",
+                Role.USER,
+                null,
+                "test123@example.com"));
     }
 
     public static String createToken(JwtUtil provider, User user) {

--- a/src/test/java/com/moodmate/api/TrackingApiTest.java
+++ b/src/test/java/com/moodmate/api/TrackingApiTest.java
@@ -8,7 +8,6 @@ import com.moodmate.domain.diary.repository.DiaryRepository;
 import com.moodmate.domain.emotion.Emotion;
 import com.moodmate.domain.emotion.EmotionRepository;
 import com.moodmate.domain.user.UserRepository;
-import com.moodmate.domain.user.entity.Role;
 import com.moodmate.domain.user.entity.User;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,11 +19,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -32,7 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class TrackingApiIntegrationTest {
+public class TrackingApiTest {
 
     @Autowired MockMvc mockMvc;
     @Autowired UserRepository userRepository;

--- a/src/test/java/com/moodmate/api/UserApiTest.java
+++ b/src/test/java/com/moodmate/api/UserApiTest.java
@@ -1,0 +1,92 @@
+package com.moodmate.api;
+
+import com.moodmate.common.JwtUtil;
+import com.moodmate.domain.diary.entity.Diary;
+import com.moodmate.domain.diary.entity.DiaryEmotion;
+import com.moodmate.domain.diary.repository.DiaryEmotionRepository;
+import com.moodmate.domain.diary.repository.DiaryRepository;
+import com.moodmate.domain.emotion.Emotion;
+import com.moodmate.domain.emotion.EmotionRepository;
+import com.moodmate.domain.user.UserRepository;
+import com.moodmate.domain.user.entity.User;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserApiTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    DiaryRepository diaryRepository;
+    @Autowired
+    EmotionRepository emotionRepository;
+    @Autowired
+    DiaryEmotionRepository diaryEmotionRepository;
+
+    @Autowired
+    JwtUtil jwtTokenProvider; // JWT 발급 유틸
+
+    private String token;
+
+    User user;
+
+    @BeforeEach
+    void setUp() {
+        diaryEmotionRepository.deleteAll();
+        diaryRepository.deleteAll();
+        emotionRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // User 생성
+        user = TestUtils.createUser(userRepository);
+
+        // 실제 JWT 토큰 발급
+        token = TestUtils.createToken(jwtTokenProvider, user);
+
+        // Emotion 생성
+        Emotion joy = emotionRepository.save(new Emotion("기쁨"));
+        Emotion sad = emotionRepository.save(new Emotion("슬픔"));
+
+        // Diary 생성 + DiaryEmotion 연결
+        Diary diary1 = Diary.builder()
+                .content("오늘은 즐거운 하루였다")
+                .date(LocalDate.of(2025, 9, 1))
+                .user(user)
+                .build();
+
+        diary1.addDiaryEmotion(new DiaryEmotion(joy, 5));
+        diary1.addDiaryEmotion(new DiaryEmotion(sad, 5));
+
+        diaryRepository.save(diary1);
+    }
+    @Test
+    public void 회원_삭제_일기_연관_있어도_삭제된다() throws Exception {
+        // given
+        Long userId = user.getId(); // setUp에서 만든 user
+
+        // when
+        mockMvc.perform(delete("/api/users/me")
+                    .cookie(new Cookie("jwt_token", token)))
+                    .andExpect(status().isOk());
+
+        // then
+        assertThat(userRepository.existsById(userId)).isFalse();
+        assertThat(diaryRepository.findAll()).isEmpty();
+        assertThat(diaryEmotionRepository.findAll()).isEmpty();
+    }
+}

--- a/src/test/java/com/moodmate/domain/tracking/TrackingServiceTest.java
+++ b/src/test/java/com/moodmate/domain/tracking/TrackingServiceTest.java
@@ -1,6 +1,7 @@
 package com.moodmate.domain.tracking;
 
 import com.moodmate.domain.diary.repository.DiaryEmotionRepository;
+import com.moodmate.domain.emotion.EmotionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,11 +17,14 @@ class TrackingServiceTest {
     private TrackingService trackingService;
     private DiaryEmotionRepository diaryEmotionRepository;
 
+    private EmotionRepository emotionRepository;
+
     @BeforeEach
     void setUp() {
         // Repository는 mock 처리
         diaryEmotionRepository = mock(DiaryEmotionRepository.class);
-        trackingService = new TrackingService(diaryEmotionRepository);
+        emotionRepository = mock(EmotionRepository.class);
+        trackingService = new TrackingService(diaryEmotionRepository, emotionRepository);
     }
 
     @Test


### PR DESCRIPTION
### 문제
```
회원 탈퇴 시, diary 테이블의 외래키 제약 조건 때문에
해당 사용자가 작성한 일기가 존재하면 삭제 불가능한 이슈 발생

[ERROR: update or delete on table "users" violates foreign key constraint "토큰" on table "diary"]
- 일기가 존재하면 회원 탈퇴 불가
- 일기가 없는 경우에는 정상적으로 탈퇴 가능
```

### 해결 방안
`1. DB Level에서 ON DELETE CASCADE 적용`
- 장점: Application 코드를 수정하지 않아도 됨
- 단점: 현재 팀원 모두 local DB 사용 중이며, 스키마가 아직 안정되지 않아 계속 수동 적용 필요

`2. Service 로직에서 사용자 일기 삭제 후 유저 삭제`
- 장점: 직관적이고 구현이 단순함
- 단점: 삭제 과정에서 여러 번 쿼리가 발생해 성능 우려

**`3. User ↔ Diary 양방향 매핑 + CascadeType.REMOVE 적용`**
- 장점: JPA에서 자동으로 Diary 삭제를 전파해줌 → 코드 단순화
- 단점: User 조회 시 Diary 관리가 함께 일어나 약간의 성능 저하 가능

<br>

### 선택 - 방안 3
- 이유: 코드가 단순하고 구현이 간단함
- DB 스키마가 안정화되면 추후 DB 레벨 ON DELETE CASCADE로 전환 고려