### PR TITLE
fix: refresh token - 로그아웃, 재로그인

### DIFF
--- a/src/main/java/com/moodmate/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/moodmate/common/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.moodmate.common;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,8 +17,11 @@ import java.util.Map;
 public class GlobalExceptionHandler {
     // 일기 없음, 감정 없음
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
-        return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    public ResponseEntity<?> handleIllegalArgument(IllegalArgumentException ex) {
+        if (ex.getMessage().contains("token type") || ex.getMessage().contains("RefreshToken not found")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", ex.getMessage()));
+        }
+        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
     }
 
     // 데이터 무결성 위반 (예: Unique 제약 위반)
@@ -50,5 +55,11 @@ public class GlobalExceptionHandler {
         Map<String, String> body = new HashMap<>();
         body.put("error", message);
         return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<?> handleJwt(JwtException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "Wrong Token."));
     }
 }

--- a/src/main/java/com/moodmate/controller/TokenController.java
+++ b/src/main/java/com/moodmate/controller/TokenController.java
@@ -1,7 +1,10 @@
 package com.moodmate.controller;
 
+import com.moodmate.domain.token.RefreshToken;
 import com.moodmate.domain.token.dto.AccessTokenResponse;
+import com.moodmate.domain.token.service.RefreshTokenService;
 import com.moodmate.domain.token.service.TokenService;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,22 +13,30 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @Tag(name = "토큰", description = "Access Token API")
 @RequiredArgsConstructor
 @RestController
 public class TokenController {
     private final TokenService tokenService;
+    private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/api/auth/refresh")
-    public ResponseEntity<AccessTokenResponse> createNewAccessToken(
+    public ResponseEntity<?> createNewAccessToken(
             @CookieValue(value = "mm-rt", required = false) String refreshToken) {
 
         if (refreshToken == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "Wrong Token."));
         }
 
-        String newAccessToken = tokenService.createNewAccessToken(refreshToken);
-
-        return ResponseEntity.ok(new AccessTokenResponse(newAccessToken));
+        try {
+            String newAccessToken = tokenService.createNewAccessToken(refreshToken);
+            return ResponseEntity.ok(new AccessTokenResponse(newAccessToken));
+        } catch (ExpiredJwtException e) {
+            refreshTokenService.deleteByRefreshToken(refreshToken);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "RefreshToken expired. Please login again."));
+        }
     }
 }

--- a/src/main/java/com/moodmate/controller/TrackingController.java
+++ b/src/main/java/com/moodmate/controller/TrackingController.java
@@ -1,9 +1,10 @@
 package com.moodmate.controller;
 
 import com.moodmate.domain.tracking.TrackingService;
-import com.moodmate.domain.tracking.dto.frequency.EmotionFrequencyResponse;
-import com.moodmate.domain.tracking.dto.ratio.EmotionRatioResponse;
-import com.moodmate.domain.tracking.dto.trend.EmotionTrendResponse;
+import com.moodmate.domain.tracking.dayOfWeek.DayOfWeekEmotionResponse;
+import com.moodmate.domain.tracking.frequency.EmotionFrequencyResponse;
+import com.moodmate.domain.tracking.ratio.EmotionRatioResponse;
+import com.moodmate.domain.tracking.trend.EmotionTrendResponse;
 import com.moodmate.domain.user.ouath.CustomOauth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -108,6 +109,29 @@ public class TrackingController {
                 startDate,
                 endDate,
                 emotionList
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/emotions/day-of-week")
+    @Operation(
+            summary = "요일별 감정 통계 조회",
+            description = "지정된 기간 동안 요일별로 감정 데이터를 분석하여 통계를 제공합니다.",
+            parameters = {
+                    @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
+                    @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01"),
+            }
+    )
+    public ResponseEntity<DayOfWeekEmotionResponse> getDayOfWeekEmotions(
+            @AuthenticationPrincipal CustomOauth2User userDetails,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        DayOfWeekEmotionResponse response = trackingService.getEmotionsByDayOfWeek(
+                userDetails.getUser().getId(),
+                startDate,
+                endDate
         );
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/moodmate/controller/TrackingController.java
+++ b/src/main/java/com/moodmate/controller/TrackingController.java
@@ -117,10 +117,16 @@ public class TrackingController {
     @GetMapping("/emotions/day-of-week")
     @Operation(
             summary = "요일별 감정 통계 조회",
-            description = "지정된 기간 동안 요일별로 감정 데이터를 분석하여 통계를 제공합니다.",
+            description = "지정된 기간 동안 요일별로 감정 데이터를 분석하여 통계를 제공합니다. 월-일 순이며, 조회할 일기가 없는 요일도 정보가 제공됩니다.",
             parameters = {
                     @Parameter(name = "startDate", description = "조회 시작 날짜", required = true, example = "2025-09-01"),
                     @Parameter(name = "endDate", description = "조회 종료 날짜", required = true, example = "2025-10-01"),
+            },
+            responses = {
+                @ApiResponse(responseCode = "200", description = "조회 성공",
+                        content = @Content(array = @ArraySchema(schema = @Schema(implementation = DayOfWeekEmotionResponse.class)))),
+                @ApiResponse(responseCode = "400", description = "잘못된 요청(잘못된 기간 설정 등)", content = @Content),
+                @ApiResponse(responseCode = "401", description = "로그인하지 않은 사용자", content = @Content)
             }
     )
     public ResponseEntity<DayOfWeekEmotionResponse> getDayOfWeekEmotions(

--- a/src/main/java/com/moodmate/domain/diary/DiaryService.java
+++ b/src/main/java/com/moodmate/domain/diary/DiaryService.java
@@ -11,8 +11,7 @@ import com.moodmate.domain.emotion.Emotion;
 import com.moodmate.domain.user.entity.User;
 import com.moodmate.domain.emotion.EmotionRepository;
 import com.moodmate.domain.user.UserRepository;
-import com.moodmate.domain.user.service.UserService;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,13 +23,14 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
     private final EmotionRepository emotionRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public Long saveDiary(Long userId, @Valid DiaryRequest dto) {
         // 작성자 조회
         User user = userRepository.findById(userId)
@@ -79,8 +79,7 @@ public class DiaryService {
                 .toList();
     }
 
-
-
+    @Transactional
     public void updateDiary(Long diaryId, DiaryRequest dto, Long userId) throws AccessDeniedException {
         // 일기 조회
         Diary diary = diaryRepository.findById(diaryId)
@@ -106,6 +105,7 @@ public class DiaryService {
         }
     }
 
+    @Transactional
     public void deleteDiary(Long diaryId, Long userId) throws AccessDeniedException {
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));

--- a/src/main/java/com/moodmate/domain/diary/repository/DiaryEmotionRepository.java
+++ b/src/main/java/com/moodmate/domain/diary/repository/DiaryEmotionRepository.java
@@ -1,7 +1,8 @@
 package com.moodmate.domain.diary.repository;
 
 import com.moodmate.domain.diary.entity.DiaryEmotion;
-import com.moodmate.domain.tracking.dto.frequency.FrequencyDto;
+import com.moodmate.domain.tracking.dayOfWeek.DayOfWeekEmotionProjection;
+import com.moodmate.domain.tracking.frequency.FrequencyDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,7 +11,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface DiaryEmotionRepository extends JpaRepository<DiaryEmotion, Long> {
-    @Query("SELECT new com.moodmate.domain.tracking.dto.frequency.FrequencyDto(de.emotion.name, COUNT(de)) " +
+    @Query("SELECT new com.moodmate.domain.tracking.frequency.FrequencyDto(de.emotion.name, COUNT(de)) " +
             "FROM DiaryEmotion de " +
             "WHERE de.diary.user.id = :userId " +
             "AND de.diary.date BETWEEN :startDate AND :endDate " +
@@ -44,5 +45,27 @@ public interface DiaryEmotionRepository extends JpaRepository<DiaryEmotion, Long
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate,
             @Param("emotions") List<String> emotions
+    );
+
+    @Query(value = """
+        SELECT 
+            CAST(EXTRACT(DOW FROM d.date) AS int) as day_of_week,
+            e.id as emotion_id,
+            e.name as emotion_name,
+            COUNT(de.id) as count,
+            AVG(de.intensity) as avg_intensity,
+            COUNT(DISTINCT d.id) as diary_count
+        FROM diary_emotion de
+        JOIN diary d ON de.diary_id = d.id
+        JOIN emotion e ON de.emotion_id = e.id
+        WHERE d.user_id = :userId
+        AND d.date BETWEEN :startDate AND :endDate
+        GROUP BY EXTRACT(DOW FROM d.date), e.id, e.name
+        ORDER BY day_of_week, count DESC
+        """, nativeQuery = true)
+    List<DayOfWeekEmotionProjection> findDayOfWeekEmotionStats(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
     );
 }

--- a/src/main/java/com/moodmate/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/moodmate/domain/diary/repository/DiaryRepository.java
@@ -11,4 +11,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     // 날짜와 사용자 ID로 일기 한 개 가져오기
     Optional<Diary> findByUserIdAndDate(Long userId, LocalDate date);
     List<Diary> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+
+    Integer countByUserIdAndDateBetween(long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/moodmate/domain/token/RefreshTokenRepository.java
+++ b/src/main/java/com/moodmate/domain/token/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByUserId(Long userId);
 
     void deleteByUserId(Long userId);
+
+    void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/moodmate/domain/token/service/RefreshTokenService.java
+++ b/src/main/java/com/moodmate/domain/token/service/RefreshTokenService.java
@@ -5,23 +5,31 @@ import com.moodmate.domain.token.RefreshTokenRepository;
 import com.moodmate.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
-
     public RefreshToken findByRefreshToken(String refreshToken) {
         return refreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(() -> new IllegalArgumentException("Unexpected Token"));
+                .orElseThrow(() -> new IllegalArgumentException("RefreshToken not found"));
     }
 
+    @Transactional
+    public void saveRefreshToken(User user, String refreshToken) {
+        refreshTokenRepository.save(new RefreshToken(user, refreshToken));
+    }
+
+    @Transactional
     public void deleteByUserId(Long userId) {
         refreshTokenRepository.deleteByUserId(userId);
     }
 
-    public void saveRefreshToken(User user, String refreshToken) {
-        refreshTokenRepository.save(new RefreshToken(user, refreshToken));
+    @Transactional
+    public void deleteByRefreshToken(String refreshToken) {
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
     }
 }

--- a/src/main/java/com/moodmate/domain/token/service/TokenService.java
+++ b/src/main/java/com/moodmate/domain/token/service/TokenService.java
@@ -4,20 +4,22 @@ import com.moodmate.config.jwt.JwtTokenProvider;
 import com.moodmate.domain.token.TokenType;
 import com.moodmate.domain.user.entity.User;
 import com.moodmate.domain.user.service.UserService;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TokenService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
     private final UserService userService;
 
+    @Transactional
     public String createNewAccessToken(String refreshToken) {
-        if(!jwtTokenProvider.validateToken(refreshToken, TokenType.REFRESH)) {
-            throw new IllegalArgumentException("Unexpected token");
-        }
+        jwtTokenProvider.validateToken(refreshToken, TokenType.REFRESH);
 
         Long userId = refreshTokenService.findByRefreshToken(refreshToken).getUser().getId();
         User user = userService.findById(userId);

--- a/src/main/java/com/moodmate/domain/tracking/TrackingMetaBase.java
+++ b/src/main/java/com/moodmate/domain/tracking/TrackingMetaBase.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto;
+package com.moodmate.domain.tracking;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekConverter.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekConverter.java
@@ -1,0 +1,38 @@
+package com.moodmate.domain.tracking.dayOfWeek;
+
+import java.time.DayOfWeek;
+import java.util.Arrays;
+
+public enum DayOfWeekConverter {
+    SUNDAY(DayOfWeek.SUNDAY, "일요일"),
+    MONDAY(DayOfWeek.MONDAY, "월요일"),
+    TUESDAY(DayOfWeek.TUESDAY, "화요일"),
+    WEDNESDAY(DayOfWeek.WEDNESDAY, "수요일"),
+    THURSDAY(DayOfWeek.THURSDAY, "목요일"),
+    FRIDAY(DayOfWeek.FRIDAY, "금요일"),
+    SATURDAY(DayOfWeek.SATURDAY, "토요일");
+
+    private final DayOfWeek dayOfWeek;
+    private final String koreanName;
+
+    DayOfWeekConverter(DayOfWeek dayOfWeek, String koreanName) {
+        this.dayOfWeek = dayOfWeek;
+        this.koreanName = koreanName;
+    }
+
+    public static DayOfWeek fromPostgresValue(int value) {
+        return values()[value].dayOfWeek;
+    }
+
+    public static String getKoreanName(DayOfWeek dayOfWeek) {
+        return values()[dayOfWeek.getValue() % 7].koreanName;
+    }
+
+    public DayOfWeek getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+}

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekEmotionProjection.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekEmotionProjection.java
@@ -1,0 +1,12 @@
+package com.moodmate.domain.tracking.dayOfWeek;
+
+import com.moodmate.domain.emotion.Emotion;
+
+public interface DayOfWeekEmotionProjection {
+    Integer getDayOfWeek(); // 0=일요일, 1=월요일, ..., 6=토요일
+    Long getEmotionId();
+    String getEmotionName();
+    Long getCount();
+    Double getAvgIntensity();
+    Long getDiaryCount();
+}

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekEmotionResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekEmotionResponse.java
@@ -1,0 +1,17 @@
+package com.moodmate.domain.tracking.dayOfWeek;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "요일별 감정 조회 응답")
+public record DayOfWeekEmotionResponse(
+        @Schema(description = "요일별 감정 조회 메타데이터")
+        WeekMeta meta,
+
+        @Schema(description = "요일별 감정 데이터",
+                example = ""
+        )
+        List<WeekDto> data
+) {
+}

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekEmotionResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/DayOfWeekEmotionResponse.java
@@ -9,9 +9,7 @@ public record DayOfWeekEmotionResponse(
         @Schema(description = "요일별 감정 조회 메타데이터")
         WeekMeta meta,
 
-        @Schema(description = "요일별 감정 데이터",
-                example = ""
-        )
+        @Schema(description = "요일별 감정 데이터(월 - 일)")
         List<WeekDto> data
 ) {
 }

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/EmotionStatistics.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/EmotionStatistics.java
@@ -1,0 +1,19 @@
+package com.moodmate.domain.tracking.dayOfWeek;
+
+import com.moodmate.domain.emotion.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record EmotionStatistics(
+        @Schema(description = "감정 종류", example = "기쁨")
+        String emotionType,
+
+        @Schema(description = "해당 감정을 느낀 횟수", example = "5")
+        Integer count,
+
+        @Schema(description = "비율 (%)", example = "62.5")
+        Double percentage,
+
+        @Schema(description = "평균 강도 (1-5)", example = "4.2")
+        Double averageIntensity
+) {
+}

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/WeekDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/WeekDto.java
@@ -1,0 +1,23 @@
+package com.moodmate.domain.tracking.dayOfWeek;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record WeekDto(
+        @Schema(description = "요일", example = "MON")
+        String dayOfWeek,
+
+        @Schema(description = "요일(한글)", example = "월요일")
+        String dayOfWeekKo,
+
+        @Schema(description = "해당 요일의 총 일기 개수", example = "8")
+        Integer diaryCount,
+
+        @Schema(description = "해당 요일의 총 감정 개수", example = "3")
+        Integer emotionCount,
+
+        @Schema(description = "해당 요일의 감정 분포")
+        List<EmotionStatistics> emotions
+) {
+}

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/WeekDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/WeekDto.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record WeekDto(
-        @Schema(description = "요일", example = "MON")
+        @Schema(description = "요일", example = "MONDAY")
         String dayOfWeek,
 
         @Schema(description = "요일(한글)", example = "월요일")

--- a/src/main/java/com/moodmate/domain/tracking/dayOfWeek/WeekMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/dayOfWeek/WeekMeta.java
@@ -1,0 +1,22 @@
+package com.moodmate.domain.tracking.dayOfWeek;
+
+import com.moodmate.domain.tracking.TrackingMetaBase;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record WeekMeta(
+        Long userId,
+
+        LocalDate startDate,
+
+        LocalDate endDate,
+
+        @Schema(description = "데이터 개수", example = "7")
+        long totalRecords,
+
+        @Schema(description = "조회된 일기 수", example = "50")
+        long totalDiaryCount,
+
+        LocalDateTime generatedAt)  implements TrackingMetaBase {}

--- a/src/main/java/com/moodmate/domain/tracking/frequency/EmotionFrequencyResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/frequency/EmotionFrequencyResponse.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto.frequency;
+package com.moodmate.domain.tracking.frequency;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/moodmate/domain/tracking/frequency/FrequencyDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/frequency/FrequencyDto.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto.frequency;
+package com.moodmate.domain.tracking.frequency;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/moodmate/domain/tracking/frequency/FrequencyMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/frequency/FrequencyMeta.java
@@ -1,6 +1,6 @@
-package com.moodmate.domain.tracking.dto.frequency;
+package com.moodmate.domain.tracking.frequency;
 
-import com.moodmate.domain.tracking.dto.TrackingMetaBase;
+import com.moodmate.domain.tracking.TrackingMetaBase;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;

--- a/src/main/java/com/moodmate/domain/tracking/ratio/EmotionRatioResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/ratio/EmotionRatioResponse.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto.ratio;
+package com.moodmate.domain.tracking.ratio;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/moodmate/domain/tracking/ratio/RatioDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/ratio/RatioDto.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto.ratio;
+package com.moodmate.domain.tracking.ratio;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/moodmate/domain/tracking/ratio/RatioMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/ratio/RatioMeta.java
@@ -1,6 +1,6 @@
-package com.moodmate.domain.tracking.dto.ratio;
+package com.moodmate.domain.tracking.ratio;
 
-import com.moodmate.domain.tracking.dto.TrackingMetaBase;
+import com.moodmate.domain.tracking.TrackingMetaBase;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;

--- a/src/main/java/com/moodmate/domain/tracking/trend/EmotionTrendResponse.java
+++ b/src/main/java/com/moodmate/domain/tracking/trend/EmotionTrendResponse.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto.trend;
+package com.moodmate.domain.tracking.trend;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/moodmate/domain/tracking/trend/TimeLineDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/trend/TimeLineDto.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto.trend;
+package com.moodmate.domain.tracking.trend;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/moodmate/domain/tracking/trend/TimeLineMeta.java
+++ b/src/main/java/com/moodmate/domain/tracking/trend/TimeLineMeta.java
@@ -1,6 +1,6 @@
-package com.moodmate.domain.tracking.dto.trend;
+package com.moodmate.domain.tracking.trend;
 
-import com.moodmate.domain.tracking.dto.TrackingMetaBase;
+import com.moodmate.domain.tracking.TrackingMetaBase;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;

--- a/src/main/java/com/moodmate/domain/tracking/trend/TimeLinePointDto.java
+++ b/src/main/java/com/moodmate/domain/tracking/trend/TimeLinePointDto.java
@@ -1,4 +1,4 @@
-package com.moodmate.domain.tracking.dto.trend;
+package com.moodmate.domain.tracking.trend;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/moodmate/domain/user/service/UserService.java
+++ b/src/main/java/com/moodmate/domain/user/service/UserService.java
@@ -6,13 +6,16 @@ import com.moodmate.domain.user.entity.User;
 import com.moodmate.domain.user.ouath.OAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;
 
+    @Transactional
     public User findOrCreateUser(OAuth2UserInfo userInfo, String provider) {
         String loginId = provider + "_" + userInfo.getProviderId();
 

--- a/src/test/java/com/moodmate/api/TestUtils.java
+++ b/src/test/java/com/moodmate/api/TestUtils.java
@@ -3,6 +3,7 @@ package com.moodmate.api;
 import com.moodmate.config.jwt.JwtTokenProvider;
 import com.moodmate.domain.token.RefreshToken;
 import com.moodmate.domain.token.RefreshTokenRepository;
+import com.moodmate.domain.token.TokenType;
 import com.moodmate.domain.user.UserRepository;
 import com.moodmate.domain.user.entity.Role;
 import com.moodmate.domain.user.entity.User;
@@ -28,4 +29,5 @@ public class TestUtils {
     public static String createAccessToken(JwtTokenProvider provider, User user) {
         return provider.createAccessToken(user);
     }
+
 }

--- a/src/test/java/com/moodmate/api/TokenApiTest.java
+++ b/src/test/java/com/moodmate/api/TokenApiTest.java
@@ -10,9 +10,13 @@ import com.moodmate.domain.emotion.Emotion;
 import com.moodmate.domain.emotion.EmotionRepository;
 import com.moodmate.domain.token.RefreshToken;
 import com.moodmate.domain.token.RefreshTokenRepository;
+import com.moodmate.domain.token.TokenType;
 import com.moodmate.domain.user.UserRepository;
 import com.moodmate.domain.user.entity.User;
 import com.moodmate.domain.user.ouath.CustomOauth2User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +29,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.crypto.SecretKey;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
@@ -33,7 +39,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +60,8 @@ public class TokenApiTest {
     @Autowired
     JwtTokenProvider jwtTokenProvider; // JWT 발급 유틸
 
-
+    @Autowired
+    JwtProperties jwtProperties;
     User user;
 
     String refreshToken;
@@ -71,13 +81,24 @@ public class TokenApiTest {
     void access_token_발급() throws Exception {
         mockMvc.perform(post("/api/auth/refresh")
                         .cookie(new Cookie("mm-rt", refreshToken)))
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken").isNotEmpty());
     }
 
     @Test
-    public void 로그아웃 () throws Exception {
+    void 만료된_AccessToken_요청_시_401() throws Exception {
+        // given: 매우 짧은 만료 시간으로 토큰 생성
+        String expiredAccessToken = jwtTokenProvider.generateExpiredToken(user.getId(), TokenType.ACCESS);
+
+        // when & then
+        mockMvc.perform(get("/api/users/me")
+                .header("Authorization", "Bearer " + expiredAccessToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("AccessToken expired."));
+    }
+
+    @Test
+    public void 로그아웃() throws Exception {
         // when: 로그아웃 요청
         mockMvc.perform(post("/api/auth/logout")
                         .header("Authorization", "Bearer " + accessToken)
@@ -87,8 +108,7 @@ public class TokenApiTest {
     }
 
     @Test
-    @Transactional
-    void 로그아웃시_RefreshToken삭제() throws Exception {
+    void 로그아웃시_RefreshToken_삭제() throws Exception {
         CustomOauth2User customOauth2User = new CustomOauth2User(user, null);
 
         // when
@@ -101,4 +121,76 @@ public class TokenApiTest {
         // then
         assertFalse(refreshTokenRepository.findByUserId(user.getId()).isPresent());
     }
+
+    @Test
+    void 만료된_RefreshToken_요청_시_401() throws Exception {
+        refreshTokenRepository.deleteAll();
+        // given: 매우 짧은 만료 시간으로 토큰 생성
+        String expiredRefreshToken = jwtTokenProvider.generateExpiredToken(
+                user.getId(),
+                TokenType.REFRESH
+        );
+        refreshTokenRepository.save(new RefreshToken(user, expiredRefreshToken));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new Cookie("mm-rt", expiredRefreshToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("RefreshToken expired. Please login again."));
+
+        // 삭제 확인
+        assertFalse(refreshTokenRepository.findByUserId(user.getId()).isPresent());
+    }
+    @Test
+    public void 잘못된_토큰_요청_401_Refresh_대신_Access() throws Exception {
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new Cookie("mm-rt", accessToken)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Wrong token type: expected REFRESH"));
+    }
+
+    @Test
+    public void 잘못된_토큰_요청_401_Refresh_토큰_없음() throws Exception {
+        mockMvc.perform(post("/api/auth/refresh"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void 잘못된_토큰_요청_401_Access_대신_Refresh() throws Exception {
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + refreshToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Wrong token type: expected ACCESS"));
+    }
+
+    @Test
+    public void 잘못된_토큰_요청_401_Access_파싱_불가() throws Exception {
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer this.is.not.a.jwt"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").isNotEmpty());
+    }
+
+    @Test
+    public void 잘못된_토큰_요청_401_Refresh_파싱_불가() throws Exception {
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new Cookie("mm-rt", "this.is.not.a.jwt")))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").isNotEmpty());
+    }
+
+    @Test
+    public void 잘못된_토큰_요청_401_DB에_없는_Refresh() throws Exception {
+        refreshTokenRepository.deleteAll();
+
+        mockMvc.perform(post("/api/auth/refresh")
+                        .cookie(new Cookie("mm-rt", refreshToken)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("RefreshToken not found"));
+    }
+
 }

--- a/src/test/java/com/moodmate/domain/tracking/TrackingServiceTest.java
+++ b/src/test/java/com/moodmate/domain/tracking/TrackingServiceTest.java
@@ -1,7 +1,9 @@
 package com.moodmate.domain.tracking;
 
 import com.moodmate.domain.diary.repository.DiaryEmotionRepository;
+import com.moodmate.domain.diary.repository.DiaryRepository;
 import com.moodmate.domain.emotion.EmotionRepository;
+import com.moodmate.domain.tracking.dayOfWeek.DayOfWeekEmotionResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,18 +15,20 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 class TrackingServiceTest {
-
     private TrackingService trackingService;
     private DiaryEmotionRepository diaryEmotionRepository;
 
     private EmotionRepository emotionRepository;
+
+    private DiaryRepository diaryRepository;
 
     @BeforeEach
     void setUp() {
         // Repository는 mock 처리
         diaryEmotionRepository = mock(DiaryEmotionRepository.class);
         emotionRepository = mock(EmotionRepository.class);
-        trackingService = new TrackingService(diaryEmotionRepository, emotionRepository);
+        diaryRepository = mock(DiaryRepository.class);
+        trackingService = new TrackingService(diaryEmotionRepository, emotionRepository, diaryRepository);
     }
 
     @Test
@@ -56,5 +60,18 @@ class TrackingServiceTest {
         )
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("필수 파라미터를 입력해주세요");
+    }
+
+    @Test
+    void 서비스_직접_호출_테스트() {
+        // given
+        Long userId = 1L;
+        LocalDate startDate = LocalDate.of(2025, 9, 1);
+        LocalDate endDate = LocalDate.of(2025, 9, 10);
+
+        DayOfWeekEmotionResponse response = trackingService.getEmotionsByDayOfWeek(userId, startDate, endDate);
+
+        System.out.println("Response: " + response);
+        assertNotNull(response);
     }
 }


### PR DESCRIPTION
### 1) 로그아웃 관련 오류
- 원인: Security Filter에서 Service 호출 시 서비스 단위 트랜잭션이 없으면 flush 타이밍이 불명확 → 캐시와 DB 반영 타이밍이 꼬일 수 있음.
- 해결: Service 레벨에서 트랜잭션을 열어 flush/commit 타이밍을 명확히 보장. @ Transactional 추가, 다른 Service에도 같은 문제가 발생하지 않도록 검토(클래스 단위는 readOnly, 쓰기 메서드만 override)

<br>
 
### 2) RefreshToken 만료 시 재로그인 시도 시 오류
- 원인: 만료된 RefreshToken에 대한 DB 처리 X
- 해결: 만료된 RefreshToken으로 요청 시 DB에서 삭제